### PR TITLE
Client performance improvements

### DIFF
--- a/src/angular/Services/markers.js
+++ b/src/angular/Services/markers.js
@@ -9,15 +9,18 @@ services.factory('Markers', ['$rootScope', '$compile', '$location', function ($r
                 {icon: feature.sector.icon}
             );
 
-            // Compile new DOM element (the popup) and link it.
-            var popup = L.popup();
-
-            var popupLinkFunc = $compile(angular.element('<div ng-controller="ServicePopupCtrl"><ng-include src="\'views/service-popup.html\'"></ng-include></div>'));
-            var popupScope = $rootScope.$new(true);
-            popupScope.feature = feature;
-            popupScope.popup = popup;
-            popup.setContent(popupLinkFunc(popupScope)[0]);
-            marker.bindPopup(popup);
+            marker.bindPopup(function (marker) {
+                var id = L.Util.stamp(marker);
+                if (!popups[id]) {
+                    popups[id] = createPopupContent();
+                    // Because rendering with $compile is asynchronous we need to
+                    // schedule popup layout update to occur after it has finished.
+                    // A simple setTimeout() should do it but if it's not working
+                    // on slower devices/networks then try increasing timeout.
+                    setTimeout(function () { marker.getPopup().update(); }, 200);
+                }
+                return popups[id];
+            });
 
             // when a user clicks on a map marker, show the service in the sidebar
             marker.on('click', function () {

--- a/src/angular/Views/service-popup.html
+++ b/src/angular/Views/service-popup.html
@@ -1,25 +1,27 @@
-<article class="serviceText" language-direction-attr>
-    <header>
-        <img class="pull-right" src="{{ service.logoUrl }}" alt="{{ service.organization.name }}" onError="this.onerror=null;this.style.display='none'"/>
-        <h3><i style="color: {{ service.sector.markerColor }}" class="glyphicon icon-{{ service.sector.glyph }}"></i> {{ service.name }}</h3>
-        <p>
-            <strong>{{ 'ORGANIZATION' |translate }}:</strong>
-            <span>{{ service.organization.name }}</span>
-        </p>
-        <p field="publicAddress" ng-if="service.publicAddress">
-            <strong>{{ 'ADDRESS' | translate }}:</strong>
-            <span>{{ service.publicAddress }}</span>
-        </p>
-        <p field="referralMethod" ng-if="service.referral.type">
-            <strong>{{ 'REFERRAL_METHOD' | translate }}:</strong>
-            <span>{{ service.referral.type }}</span>
-        </p>
-        <p field="intakeCriteria" ng-if="service.intakeCriteria != false" class="text-crimson">
-            <strong>{{ 'INTAKE_CRITERIA' | translate }}:</strong>
-            <span ng-if="service.intakeCriteria">{{ service.intakeCriteria }}</span>
-        </p>
-        <div field="infoLink" ng-if="service.infoLink" class="more-info">
-            <a class="btn btn-primary btn-xs" href="{{ service.infoLink.url }}" target="_blank" role="button">{{ 'INFO_LINK' | translate }}</a>
-        </div>
-    </header>
-</article>
+<div>
+  <article class="serviceText" language-direction-attr>
+      <header>
+          <img class="pull-right" src="{{ service.logoUrl }}" alt="{{ service.organization.name }}" onError="this.onerror=null;this.style.display='none'"/>
+          <h3><i style="color: {{ service.sector.markerColor }}" class="glyphicon icon-{{ service.sector.glyph }}"></i> {{ service.name }}</h3>
+          <p>
+              <strong>{{ 'ORGANIZATION' |translate }}:</strong>
+              <span>{{ service.organization.name }}</span>
+          </p>
+          <p field="publicAddress" ng-if="service.publicAddress">
+              <strong>{{ 'ADDRESS' | translate }}:</strong>
+              <span>{{ service.publicAddress }}</span>
+          </p>
+          <p field="referralMethod" ng-if="service.referral.type">
+              <strong>{{ 'REFERRAL_METHOD' | translate }}:</strong>
+              <span>{{ service.referral.type }}</span>
+          </p>
+          <p field="intakeCriteria" ng-if="service.intakeCriteria != false" class="text-crimson">
+              <strong>{{ 'INTAKE_CRITERIA' | translate }}:</strong>
+              <span ng-if="service.intakeCriteria">{{ service.intakeCriteria }}</span>
+          </p>
+          <div field="infoLink" ng-if="service.infoLink" class="more-info">
+              <a class="btn btn-primary btn-xs" href="{{ service.infoLink.url }}" target="_blank" role="button">{{ 'INFO_LINK' | translate }}</a>
+          </div>
+      </header>
+  </article>
+</div>

--- a/src/angular/controllers/map.controller.js
+++ b/src/angular/controllers/map.controller.js
@@ -167,12 +167,12 @@ controllers.controller('MapCtrl', ['$scope', '$rootScope', '$location', '$transl
     // when the map is showing
     $("#serviceList").scroll(_.throttle(function() {
         if (!mc.hasClass('map-hide')) {
-            toggleMap();
+            window.toggleMap();
         }
     }, 10));
 
     // HACK: using a global here so we can use an onclick="toggleMap()"
-    toggleMap = function() {
+    window.toggleMap = function () {
         mc.toggleClass('map-hide');
         map.invalidateSize();
     };


### PR DESCRIPTION
Rendering location popup content on-demand

Doing all of the location popup content on initial load was causing a huge
bottleneck and leaving the UI unresponsive for > 10 seconds.